### PR TITLE
Fix OS detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Dynamic Library Loading Example
 
 This is a small but complete example, written in C, which shows:
 
+* How to build a host executable into which a dynamic library can be loaded.
 * How to build a dynamic library with intentional holes.
 * How to load and use such a library within a host runtime, using the
   `dlsym()` family of functions.
@@ -17,8 +18,9 @@ In this case, the `host` executable exports a function named
 libraries. It opens each library, looks up the `run` function,
 and calls it.
 
-The code has been tested on OS X (compiled with Clang) and
-Linux (compiled with Gcc, and running in a Gnu environment).
+The code has been tested on OS X (compiled with Clang) and Linux (compiled
+with Gcc and Clang, and running in a Gnu environment).
+
 
 Subdirectories of this project
 ------------------------------

--- a/build
+++ b/build
@@ -52,6 +52,7 @@ COMPILE_C=("${CC}" -std=c99 -g -c)
 COMPILE_LIB_C=("${COMPILE_C[@]}")
 LINK_BIN=("${CC}" -g)
 LINK_BIN_SUFFIX=()
+LINK_LIB=("${CC}" -g)
 
 # Figure out what OS and compiler we have, and set up build commands
 # accordingly.
@@ -91,20 +92,20 @@ case "${WHAT_CC}" in
         # `-dynamiclib` -- Output a dynamic-linked (shared) library.
         # `-undefined dynamic_lookup` -- Allow missing/unlinked symbols in the
         #   output. Cause these symbols to be looked up at library load/runtime.
-        LINK_LIB=("${CC}" -g -dynamiclib -undefined dynamic_lookup)
+        LINK_LIB+=(-dynamiclib -undefined dynamic_lookup)
     ;;
     (gcc)
         # `-fPIC` -- Produce position-independent code.
-        COMPILE_LIB_C=("${COMPILE_C[@]}" -fPIC)
+        COMPILE_LIB_C+=(-fPIC)
 
         # `-shared` -- Output a dynamic-linked (shared) library.
         # `-Ur` -- Allow missing/unlinked symbols in the output. Cause these
         #   symbols to be looked up at library load/runtime.
-        LINK_LIB=("${CC}" -g -shared -Ur)
+        LINK_LIB+=(-shared -Ur)
 
         # `-rdynamic` -- Export symbols defined in the binary such that they
         #   may be found by runtime-loaded libraries.
-        LINK_BIN=("${LINK_BIN[@]}" -rdynamic)
+        LINK_BIN+=(-rdynamic)
     ;;
 esac
 
@@ -115,7 +116,7 @@ case "${WHAT_OS}" in
     (linux)
         # `-ldl` -- Link this binary with the `dl` (dynamic linker) library.
         #   Needs to come at the end of the link command.
-        LINK_BIN_SUFFIX=(-ldl)
+        LINK_BIN_SUFFIX+=(-ldl)
     ;;
 esac
 

--- a/build
+++ b/build
@@ -51,6 +51,7 @@ fi
 COMPILE_C=("${CC}" -std=c99 -g -c)
 COMPILE_LIB_C=("${COMPILE_C[@]}")
 LINK_BIN=("${CC}" -g)
+LINK_BIN_SUFFIX=()
 
 # Figure out if we're using Clang or Gcc, and set up build commands
 # accordingly.
@@ -81,7 +82,9 @@ case "${WHAT_CC}" in
         # `-rdynamic` -- Export symbols defined in the binary such that they
         #   may be found by runtime-loaded libraries.
         # `-ldl` -- Link this binary with the `dl` (dynamic linker) library.
+        #   Needs to come at the end of the link command.
         LINK_BIN=("${LINK_BIN[@]}" -rdynamic -ldl)
+        LINK_BIN_SUFFIX=(-ldl)
     ;;
     (*)
         echo 1>&2 "Sorry: Cannot use compiler: ${WHAT_CC}"
@@ -110,14 +113,15 @@ function buildProject {
 
     if [[ ${type} == 'host' ]]; then
         "${COMPILE_C[@]}" -o "${projBase}.o" "${sources[@]}" \
-        || exit 1
+            || exit 1
         "${LINK_BIN[@]}" -o "${projBase}" "${projBase}.o" \
-        || exit 1
+            "${LINK_BIN_SUFFIX[@]}" \
+            || exit 1
     else
         "${COMPILE_LIB_C[@]}" -o "${projBase}.o" "${sources[@]}" \
-        || exit 1
+            || exit 1
         "${LINK_LIB[@]}" -o "${projBase}.lib" "${projBase}.o" \
-        || exit 1
+            || exit 1
     fi
 }
 

--- a/build
+++ b/build
@@ -54,8 +54,7 @@ LINK_BIN=("${CC}" -g)
 LINK_BIN_SUFFIX=()
 LINK_LIB=("${CC}" -g)
 
-# Figure out what OS and compiler we have, and set up build commands
-# accordingly.
+# Figure out what OS we have, and set up build commands accordingly.
 
 if [[ ${OSTYPE} == '' ]]; then
     OSTYPE="$(uname)"
@@ -71,28 +70,6 @@ case "${OSTYPE}" in
     (*)
         echo 1>&2 "Sorry: Unknown OS type: ${OSTYPE}"
         exit 1
-    ;;
-esac
-
-WHAT_CC="$("${CC}" --version | awk '
-    BEGIN          { result = "unknown"   }
-    /clang/        { result = "clang"     }
-    /gcc/ || /GCC/ { result = "gcc"       }
-    END            { printf("%s", result) }
-')"
-
-if [[ ${WHAT_CC} == 'unknown' ]]; then
-    echo 1>&2 'Sorry: Unknown compiler'
-    "${CC}" --version 1>&2
-    exit 1
-fi
-
-case "${WHAT_CC}" in
-    (clang)
-        : # Nothing extra to add.
-    ;;
-    (gcc)
-        : # Nothing extra to add.
     ;;
 esac
 

--- a/build
+++ b/build
@@ -110,7 +110,8 @@ case "${WHAT_OS}" in
     (bsd)
         # `-dynamiclib` -- Output a dynamic-linked (shared) library.
         # `-undefined dynamic_lookup` -- Allow missing/unlinked symbols in the
-        #   output. Cause these symbols to be looked up at library load/runtime.
+        #   output. That will cause such symbols to be looked up when the
+        #   library is loaded or run.
         LINK_LIB+=(-dynamiclib -undefined dynamic_lookup)
     ;;
     (linux)

--- a/build
+++ b/build
@@ -89,10 +89,7 @@ fi
 
 case "${WHAT_CC}" in
     (clang)
-        # `-dynamiclib` -- Output a dynamic-linked (shared) library.
-        # `-undefined dynamic_lookup` -- Allow missing/unlinked symbols in the
-        #   output. Cause these symbols to be looked up at library load/runtime.
-        LINK_LIB+=(-dynamiclib -undefined dynamic_lookup)
+        : # Nothing extra to add.
     ;;
     (gcc)
         # `-fPIC` -- Produce position-independent code.
@@ -111,7 +108,10 @@ esac
 
 case "${WHAT_OS}" in
     (bsd)
-        : # Nothing more to do.
+        # `-dynamiclib` -- Output a dynamic-linked (shared) library.
+        # `-undefined dynamic_lookup` -- Allow missing/unlinked symbols in the
+        #   output. Cause these symbols to be looked up at library load/runtime.
+        LINK_LIB+=(-dynamiclib -undefined dynamic_lookup)
     ;;
     (linux)
         # `-ldl` -- Link this binary with the `dl` (dynamic linker) library.

--- a/build
+++ b/build
@@ -92,9 +92,6 @@ case "${WHAT_CC}" in
         : # Nothing extra to add.
     ;;
     (gcc)
-        # `-fPIC` -- Produce position-independent code.
-        COMPILE_LIB_C+=(-fPIC)
-
         # `-shared` -- Output a dynamic-linked (shared) library.
         # `-Ur` -- Allow missing/unlinked symbols in the output. Cause these
         #   symbols to be looked up at library load/runtime.
@@ -115,6 +112,9 @@ case "${WHAT_OS}" in
         LINK_LIB+=(-dynamiclib -undefined dynamic_lookup)
     ;;
     (linux)
+        # `-fPIC` -- Produce position-independent code.
+        COMPILE_LIB_C+=(-fPIC)
+
         # `-ldl` -- Link this binary with the `dl` (dynamic linker) library.
         #   Needs to come at the end of the link command.
         LINK_BIN_SUFFIX+=(-ldl)

--- a/build
+++ b/build
@@ -53,8 +53,25 @@ COMPILE_LIB_C=("${COMPILE_C[@]}")
 LINK_BIN=("${CC}" -g)
 LINK_BIN_SUFFIX=()
 
-# Figure out if we're using Clang or Gcc, and set up build commands
+# Figure out what OS and compiler we have, and set up build commands
 # accordingly.
+
+if [[ ${OSTYPE} == '' ]]; then
+    OSTYPE="$(uname)"
+fi
+
+case "${OSTYPE}" in
+    (linux* | Linux*)
+        WHAT_OS='linux'
+    ;;
+    (darwin* | Darwin* | *bsd* | *BSD*)
+        WHAT_OS='bsd'
+    ;;
+    (*)
+        echo 1>&2 "Sorry: Unknown OS type: ${OSTYPE}"
+        exit 1
+    ;;
+esac
 
 WHAT_CC="$("${CC}" --version | awk '
     BEGIN          { result = "unknown"   }
@@ -62,6 +79,12 @@ WHAT_CC="$("${CC}" --version | awk '
     /gcc/ || /GCC/ { result = "gcc"       }
     END            { printf("%s", result) }
 ')"
+
+if [[ ${WHAT_CC} == 'unknown' ]]; then
+    echo 1>&2 'Sorry: Unknown compiler'
+    "${CC}" --version 1>&2
+    exit 1
+fi
 
 case "${WHAT_CC}" in
     (clang)
@@ -85,10 +108,6 @@ case "${WHAT_CC}" in
         #   Needs to come at the end of the link command.
         LINK_BIN=("${LINK_BIN[@]}" -rdynamic -ldl)
         LINK_BIN_SUFFIX=(-ldl)
-    ;;
-    (*)
-        echo 1>&2 "Sorry: Cannot use compiler: ${WHAT_CC}"
-        exit 1
     ;;
 esac
 

--- a/build
+++ b/build
@@ -104,9 +104,17 @@ case "${WHAT_CC}" in
 
         # `-rdynamic` -- Export symbols defined in the binary such that they
         #   may be found by runtime-loaded libraries.
+        LINK_BIN=("${LINK_BIN[@]}" -rdynamic)
+    ;;
+esac
+
+case "${WHAT_OS}" in
+    (bsd)
+        : # Nothing more to do.
+    ;;
+    (linux)
         # `-ldl` -- Link this binary with the `dl` (dynamic linker) library.
         #   Needs to come at the end of the link command.
-        LINK_BIN=("${LINK_BIN[@]}" -rdynamic -ldl)
         LINK_BIN_SUFFIX=(-ldl)
     ;;
 esac

--- a/build
+++ b/build
@@ -92,14 +92,7 @@ case "${WHAT_CC}" in
         : # Nothing extra to add.
     ;;
     (gcc)
-        # `-shared` -- Output a dynamic-linked (shared) library.
-        # `-Ur` -- Allow missing/unlinked symbols in the output. Cause these
-        #   symbols to be looked up at library load/runtime.
-        LINK_LIB+=(-shared -Ur)
-
-        # `-rdynamic` -- Export symbols defined in the binary such that they
-        #   may be found by runtime-loaded libraries.
-        LINK_BIN+=(-rdynamic)
+        : # Nothing extra to add.
     ;;
 esac
 
@@ -115,10 +108,19 @@ case "${WHAT_OS}" in
         # `-fPIC` -- Produce position-independent code.
         COMPILE_LIB_C+=(-fPIC)
 
+        # `-rdynamic` -- Export symbols defined in the binary such that they
+        #   may be found by runtime-loaded libraries.
+        LINK_BIN+=(-rdynamic)
+
         # `-ldl` -- Link this binary with the `dl` (dynamic linker) library.
         #   Needs to come at the end of the link command.
         LINK_BIN_SUFFIX+=(-ldl)
-    ;;
+
+        # `-shared` -- Output a dynamic-linked (shared) library.
+        # `-Ur` -- Allow missing/unlinked symbols in the output. Cause these
+        #   symbols to be looked up at library load/runtime.
+        LINK_LIB+=(-shared -Ur)
+        ;;
 esac
 
 

--- a/build
+++ b/build
@@ -54,26 +54,40 @@ LINK_BIN=("${CC}" -g)
 
 # Figure out if we're using Clang or Gcc, and set up build commands
 # accordingly.
-if (cc -v 2>&1 | grep clang) > /dev/null; then
-    # `-dynamiclib` -- Output a dynamic-linked (shared) library.
-    # `-undefined dynamic_lookup` -- Allow missing/unlinked symbols in the
-    #   output. Cause these symbols to be looked up at library load/runtime.
-    LINK_LIB=("${CC}" -g -dynamiclib -undefined dynamic_lookup)
-elif (cc -v 2>&1 | grep gcc) > /dev/null; then
-    # `-fPIC` -- Produce position-independent code.
-    COMPILE_LIB_C=("${COMPILE_C[@]}" -fPIC)
-    # `-shared` -- Output a dynamic-linked (shared) library.
-    # `-Ur` -- Allow missing/unlinked symbols in the output. Cause these
-    #   symbols to be looked up at library load/runtime.
-    LINK_LIB=("${CC}" -g -shared -Ur)
-    # `-rdynamic` -- Export symbols defined in the binary such that they
-    #   may be found by runtime-loaded libraries.
-    # `-ldl` -- Link this binary with the `dl` (dynamic linker) library.
-    LINK_BIN=("${LINK_BIN[@]}" -rdynamic -ldl)
-else
-    echo 'Unknown compiler. Sorry!' 1>&2
-    exit 1
-fi
+
+WHAT_CC="$("${CC}" --version | awk '
+    BEGIN          { result = "unknown"   }
+    /clang/        { result = "clang"     }
+    /gcc/ || /GCC/ { result = "gcc"       }
+    END            { printf("%s", result) }
+')"
+
+case "${WHAT_CC}" in
+    (clang)
+        # `-dynamiclib` -- Output a dynamic-linked (shared) library.
+        # `-undefined dynamic_lookup` -- Allow missing/unlinked symbols in the
+        #   output. Cause these symbols to be looked up at library load/runtime.
+        LINK_LIB=("${CC}" -g -dynamiclib -undefined dynamic_lookup)
+    ;;
+    (gcc)
+        # `-fPIC` -- Produce position-independent code.
+        COMPILE_LIB_C=("${COMPILE_C[@]}" -fPIC)
+
+        # `-shared` -- Output a dynamic-linked (shared) library.
+        # `-Ur` -- Allow missing/unlinked symbols in the output. Cause these
+        #   symbols to be looked up at library load/runtime.
+        LINK_LIB=("${CC}" -g -shared -Ur)
+
+        # `-rdynamic` -- Export symbols defined in the binary such that they
+        #   may be found by runtime-loaded libraries.
+        # `-ldl` -- Link this binary with the `dl` (dynamic linker) library.
+        LINK_BIN=("${LINK_BIN[@]}" -rdynamic -ldl)
+    ;;
+    (*)
+        echo 1>&2 "Sorry: Cannot use compiler: ${WHAT_CC}"
+        exit 1
+    ;;
+esac
 
 
 #


### PR DESCRIPTION
It turned out what I'd thought were compiler-specific arguments were in fact entirely *OS*-specific arguments.